### PR TITLE
fix handle external image update

### DIFF
--- a/k3s-openstack/main.tf
+++ b/k3s-openstack/main.tf
@@ -79,6 +79,12 @@ resource "openstack_compute_instance_v2" "node" {
     destination_type      = "volume"
     delete_on_termination = false
   }
+
+  lifecycle {
+    ignore_changes = [
+      block_device.0.uuid
+    ]
+  }
 }
 
 resource "openstack_networking_port_v2" "mgmt" {


### PR DESCRIPTION
Terraform doesn't notice that the root block device was updated by
another entitiy, so ignoring uuid changes. If the root block device
needs to be updated, the image_id attribute will change too.